### PR TITLE
Use the job name for mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,10 @@ pull_request_rules:
     - author=renovate[bot]
     - label!=no-mergify
     - "#changes-requested-reviews-by=0"
-    - check-success=8
+    - check-success=ci-smoketests
+    - check-success=ci-typing
+    - "check-success=ci-testsuite (311)"
+    - "check-success=ci-testsuite (312)"
 
   - name: default
     actions:
@@ -18,4 +21,7 @@ pull_request_rules:
     conditions:
     - label!=no-mergify
     - '#approved-reviews-by>=1'
-    - check-success=8
+    - check-success=ci-smoketests
+    - check-success=ci-typing
+    - "check-success=ci-testsuite (311)"
+    - "check-success=ci-testsuite (312)"


### PR DESCRIPTION
According to mergify documentation (see
https://docs.mergify.com/integrations/gha/) GitHub actions needs to have only job name in the `check-success` condition.