### PR TITLE
Unbreak Pagure repository configuration

### DIFF
--- a/.github/workflows/workflow_config.toml
+++ b/.github/workflows/workflow_config.toml
@@ -25,12 +25,12 @@ closed = "Done"
 type = "pagure"
 enabled = true  # Enable/Disable Pagure instance
 instance_url = "https://pagure.io/"  # URL for pagure endpoint
-label = "cpe"  # Label marking issues to by synchronized
 blocked_label = "blocked"  # Label that is marking blocked issues
 usermap = "pagureio_jira_usermap.toml"  # Map pagure.io to JIRA users
 
 [[instances."pagure.io".query_repositories]]
 namespace = "fedora-infra"
+label = "cpe"  # Label marking issues to by synchronized
 
 [instances."pagure.io".repositories]
 # List of repositories to check for tickets


### PR DESCRIPTION
Previously, tickets on all Pagure repositories were only considered if they had the "cpe" label, but we don’t have them on the individually configured repositories.