### PR TITLE
Fix the issue with tickets not transitioning to new state correctly

### DIFF
--- a/.github/workflows/sync_trackers.yml
+++ b/.github/workflows/sync_trackers.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Run the script
       run: |
         poetry install
-        poetry run jira_sync -v sync-tickets
+        poetry run jira_sync sync-tickets

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ cython_debug/
 # Project specific
 # Ignore any local configuration file
 config.toml
+pagureio_jira_usermap.toml
+githubcom_jira_usermap.toml

--- a/jira_sync/main.py
+++ b/jira_sync/main.py
@@ -56,6 +56,7 @@ def sync_tickets(config_file: str, dry_run: bool):
     )
 
     statuses = jira_config.statuses
+    status_values = list(statuses.model_dump().values())
 
     all_jira_issues = set()
     # This will be filled with JIRA issues that were matched with
@@ -169,9 +170,9 @@ def sync_tickets(config_file: str, dry_run: bool):
             # Only move to new state from status we know
             if not (
                 repo_issue.status == IssueStatus.new
-                and jira_issue.fields.status.name not in statuses
+                and jira_issue.fields.status.name not in status_values
             ):
-                log.debug(
+                log.info(
                     "Transition issue %s from %s to %s",
                     jira_issue.key,
                     jira_issue.fields.status.name,
@@ -180,7 +181,7 @@ def sync_tickets(config_file: str, dry_run: bool):
                 jira.transition_issue(jira_issue, jira_status)
                 jira.add_label(jira_issue, jira_config.label)
             else:
-                log.debug(
+                log.info(
                     "Not transitioning issue %s from %s to %s",
                     jira_issue.key,
                     jira_issue.fields.status.name,


### PR DESCRIPTION
The issue was with how the jira statuses configuration was handled after the refactoring. It didn't returned list of states anymore, but rather just a string which didn't matched against the status in JIRA.

I also updated the .gitignore with new config files.

Removing the verbose mode from the github action as it was used just to troubleshoot this issue.

Moved few log messages from debug to info as they will be crucial in identifying the issue.