### PR TITLE
mypy: Explicitly use Python version 3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,5 @@ commands_pre =
 commands = ruff format --diff jira_sync/ tests/
 
 [testenv:mypy]
+base_python = 3.12
 commands = mypy jira_sync/


### PR DESCRIPTION
With Python >= 3.13, mypy complains about Pydantic child classes narrowing the type of a field, e.g. if it’s optional in the generic base class but mandatory in a concrete implementation.