### PR TITLE
Fix verifying assignees

### DIFF
--- a/jira_sync/repositories/base.py
+++ b/jira_sync/repositories/base.py
@@ -11,7 +11,6 @@ from typing import Annotated, Any, ClassVar, Self, Type
 from weakref import ProxyType, proxy
 
 import requests
-from jira import Issue as JiraIssue
 from pydantic import AnyUrl
 
 from ..config.model import InstanceConfig
@@ -40,7 +39,6 @@ class Issue:
     content: str
     assignee: str | None
     status: IssueStatus
-    jira_issue: JiraIssue | None = None
 
 
 class APIBase:

--- a/tests/common.py
+++ b/tests/common.py
@@ -15,9 +15,14 @@ class JiraStatus(HashableModel):
     name: str = "NEW"
 
 
+class JiraAssignee(HashableModel):
+    key: str = "other_jira_user"
+    emailAddress: str = "other-address@example.com"
+
+
 class JiraIssueFields(HashableModel):
     description: str | None = None
-    assignee: str | None = None
+    assignee: JiraAssignee | None = None
     status: JiraStatus = JiraStatus()
     labels: tuple[str, ...] = ()
 


### PR DESCRIPTION
commit 79603c76726d66a6859571a5925e9f72ef9a4c5c
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Nov 27 16:22:09 2024 +0100

    Drop unused jira_issue member in forge issues
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit d5fcea56468c6f6d5e3794676771b880792bd216
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Nov 27 12:17:21 2024 +0100

    Fix verifying JIRA assignees
    
    JIRA users are complex objects, so this requires looking up mapped JIRA
    users against key (user name) and email address.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>