### PR TITLE
Verify authentication with JIRA up front

### DIFF
--- a/jira_sync/jira_wrapper.py
+++ b/jira_sync/jira_wrapper.py
@@ -59,6 +59,8 @@ class JIRA:
             self._jira = jira.client.JIRA(
                 str(jira_config.instance_url), token_auth=jira_config.token
             )
+            # Establish that the connection is authenticated, will throw an exception without.
+            self._jira.session()
 
         self.project_statuses = {}
 

--- a/jira_sync/main.py
+++ b/jira_sync/main.py
@@ -5,6 +5,7 @@ Script for synchronizing tickets from various trackers in JIRA project.
 import logging
 
 import click
+from jira.exceptions import JIRAError
 
 from .config import load_configuration
 from .jira_wrapper import JiraRunMode
@@ -69,5 +70,8 @@ def sync_tickets(config_file: str, run_mode: JiraRunMode):
     :param run_mode: How JIRA is supposed to be accessed
     """
     config = load_configuration(config_file)
-    sync_mgr = SyncManager(config=config, run_mode=run_mode)
+    try:
+        sync_mgr = SyncManager(config=config, run_mode=run_mode)
+    except JIRAError as e:
+        raise click.ClickException(e.text) from e
     sync_mgr.sync_issues()

--- a/tests/test_jira_wrapper.py
+++ b/tests/test_jira_wrapper.py
@@ -74,6 +74,7 @@ class TestJIRA:
                 str(jira_config.instance_url), token_auth=jira_config.token
             )
             assert jira_obj._jira == mocked_jira_pkg.client.JIRA.return_value
+            jira_obj._jira.session.assert_called_once()
         assert jira_obj.jira_config == jira_config
         assert jira_obj.run_mode == run_mode
 


### PR DESCRIPTION
Previously, JIRA would return anonymous results if e.g. the token is expired.