### PR TITLE
Update for sync_from_upstream

### DIFF
--- a/.github/workflows/workflow_config.toml
+++ b/.github/workflows/workflow_config.toml
@@ -2,11 +2,12 @@
 
 [general.jira]
 instance_url = "https://issues.redhat.com"  # JIRA instance URL
-project = "CPE"  # Name of the project to sync tickets to
+project = "CLE"  # Name of the project to sync tickets to
 token = "$secrets.jira_token"  # API token to use for authentication
 default_issue_type = "Story"  # Issue type to use when creating new issue in JIRA
-label = "infra-releng"  # Label used for all issues created by this script
+label = "jira_sync"  # Label used for all issues created by this script
 story_points_field = "customfield_12310243" # JIRA issue field used for story points (this could be custom field)
+external_url_field = "customfield_12317242" # JIRA field used for external URL (this is used to match the JIRA issue with upstream issue)
 
 # Map the ticket state to JIRA project state
 # Recognizable states are:
@@ -18,7 +19,7 @@ story_points_field = "customfield_12310243" # JIRA issue field used for story po
 new = "New"
 assigned = "In Progress"
 blocked = "Blocked"
-closed = "Done"
+closed = "Closed"
 
 
 # Pagure configuration

--- a/.github/workflows/workflow_config.toml
+++ b/.github/workflows/workflow_config.toml
@@ -8,6 +8,12 @@ default_issue_type = "Story"  # Issue type to use when creating new issue in JIR
 label = "jira_sync"  # Label used for all issues created by this script
 story_points_field = "customfield_12310243" # JIRA issue field used for story points (this could be custom field)
 external_url_field = "customfield_12317242" # JIRA field used for external URL (this is used to match the JIRA issue with upstream issue)
+blocked_field = "customfield_12316543" # JIRA issue field used for marking ticket as blocked
+
+# Map the boolean values to JIRA field values
+[general.jira.blocked_values]
+true = 14656
+false = 14657
 
 # Map the ticket state to JIRA project state
 # Recognizable states are:
@@ -18,7 +24,7 @@ external_url_field = "customfield_12317242" # JIRA field used for external URL (
 [general.jira.statuses]
 new = "New"
 assigned = "In Progress"
-blocked = "Blocked"
+blocked = "In Progress"
 closed = "Closed"
 
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,6 +10,12 @@ default_issue_type = "Story"  # Issue type to use when creating new issue in JIR
 label = "label"  # Label used for all issues created by this script
 story_points_field = "" # JIRA issue field used for story points (this could be custom field)
 external_url_field = "" # JIRA field used for external URL (this is used to match the JIRA issue with upstream issue)
+blocked_field = "" # JIRA issue field used for marking ticket as blocked
+
+# Map the boolean values to JIRA field values
+[general.jira.blocked_values]
+true = 1
+false = 2
 
 # Map the ticket status to JIRA project status
 # Recognizable statuses are:

--- a/config.example.toml
+++ b/config.example.toml
@@ -9,6 +9,7 @@ token = "token"  # API token to use for authentication
 default_issue_type = "Story"  # Issue type to use when creating new issue in JIRA
 label = "label"  # Label used for all issues created by this script
 story_points_field = "" # JIRA issue field used for story points (this could be custom field)
+external_url_field = "" # JIRA field used for external URL (this is used to match the JIRA issue with upstream issue)
 
 # Map the ticket status to JIRA project status
 # Recognizable statuses are:

--- a/jira_sync/config/model.py
+++ b/jira_sync/config/model.py
@@ -22,6 +22,7 @@ class JiraConfig(BaseModel):
     default_issue_type: str
     label: str
     story_points_field: str = ""
+    external_url_field: str
 
     statuses: StatusesConfig
 

--- a/jira_sync/config/model.py
+++ b/jira_sync/config/model.py
@@ -15,6 +15,11 @@ class StatusesConfig(BaseModel):
     closed: str
 
 
+class BlockValuesConfig(BaseModel):
+    true: int
+    false: int
+
+
 class JiraConfig(BaseModel):
     instance_url: HttpUrl
     project: str
@@ -23,6 +28,9 @@ class JiraConfig(BaseModel):
     label: str
     story_points_field: str = ""
     external_url_field: str
+    blocked_field: str
+
+    blocked_values: BlockValuesConfig
 
     statuses: StatusesConfig
 

--- a/jira_sync/jira_wrapper.py
+++ b/jira_sync/jira_wrapper.py
@@ -108,16 +108,12 @@ class JIRA:
     def create_issue(
         self,
         *,
-        summary: str,
-        description: str,
         url: str,
         labels: Collection[str] | str | None = None,
     ) -> Issue | None:
         """
         Create a new issue in JIRA.
 
-        :param summary: Name of the ticket
-        :param description: Description of the ticket
         :param url: URL to add to url field, it is also added to description
         :param labels: Label(s) for the issue, if any
 
@@ -132,8 +128,7 @@ class JIRA:
 
         issue_dict: dict[str, Any] = {
             "project": {"key": self.jira_config.project},
-            "summary": summary,
-            "description": url + "\n\n" + description,
+            "summary": url,
             "issuetype": {"name": self.jira_config.default_issue_type},
             "labels": labels if labels else [],
         }

--- a/jira_sync/jira_wrapper.py
+++ b/jira_sync/jira_wrapper.py
@@ -235,6 +235,29 @@ class JIRA:
         log.debug("%s: Adding story points: %d", issue.key, story_points)
         return changes | {self.jira_config.story_points_field: [{"set": story_points}]}
 
+    def add_blocked_status(self, issue: Issue, blocked: bool, changes: dict) -> dict:
+        """
+        Add blocked state to issue.
+
+        :param issue: Issue object
+        :param blocked: True/False corresponding to blocked state
+        :param changes: Dictionary containing all the changes for the issue
+
+        :return: Updated dictionary of changes
+        """
+        # Convert boolean to values used by JIRA
+        blocked = dict(self.jira_config.blocked_values)[str(blocked).lower()]
+        if not self.jira_config.blocked_field:
+            log.debug("Blocked field in jira is not set. Skipping adding blocked status.")
+            return changes
+
+        if getattr(issue.fields, self.jira_config.blocked_field) == {"id": str(blocked)}:
+            log.debug("%s: blocked field already set to correct value. Skipping.", issue.key)
+            return changes
+
+        log.debug("%s: Filling blocked field: %s", issue.key, {"id": str(blocked)})
+        return changes | {self.jira_config.blocked_field: [{"set": {"id": str(blocked)}}]}
+
     def update_issue(self, issue: Issue, changes: dict) -> None:
         """
         Update fields on the issue.

--- a/jira_sync/sync_mgr.py
+++ b/jira_sync/sync_mgr.py
@@ -318,4 +318,7 @@ class SyncManager:
                 changes,
             )
             changes = self._jira.add_story_points(jira_issue, forge_issue.story_points, changes)
+            changes = self._jira.add_blocked_status(
+                jira_issue, forge_issue.status == IssueStatus.blocked, changes
+            )
             self._jira.update_issue(jira_issue, changes)

--- a/tests/common.py
+++ b/tests/common.py
@@ -431,6 +431,11 @@ def gen_test_config(*, instances_enabled, repositories_enabled):
                 "label": "label",
                 "story_points_field": "story_points",
                 "external_url_field": "external_url",
+                "blocked_field": "blocked_field",
+                "blocked_values": {
+                    "true": 1,
+                    "false": 0,
+                },
                 "statuses": {
                     "new": "NEW",
                     "assigned": "IN_PROGRESS",

--- a/tests/common.py
+++ b/tests/common.py
@@ -23,6 +23,7 @@ class JiraAssignee(HashableModel):
 class JiraIssueFields(HashableModel):
     description: str | None = None
     assignee: JiraAssignee | None = None
+    external_url: str | None = None
     status: JiraStatus = JiraStatus()
     labels: tuple[str, ...] = ()
 
@@ -100,14 +101,14 @@ TEST_PAGURE_JIRA_ISSUES = [
             {
                 "fields": {
                     "labels": ["foo", "label", "pagure.io:namespace/test1"],
-                    "description": "https://pagure.io/namespace/test1/issue/4",
+                    "external_url": "https://pagure.io/namespace/test1/issue/4",
                     "status": {"name": "NEW"},
                 },
             },
             {
                 "fields": {
                     "labels": ["bar", "label", "pagure.io:test2"],
-                    "description": "https://pagure.io/test2/issue/2",
+                    "external_url": "https://pagure.io/test2/issue/2",
                     "status": {"name": "IN_PROGRESS"},
                 },
             },
@@ -115,21 +116,21 @@ TEST_PAGURE_JIRA_ISSUES = [
             {
                 "fields": {
                     "labels": ["label", "pagure.io:test2"],
-                    "description": "https://pagure.io/test2/issue/6",
+                    "external_url": "https://pagure.io/test2/issue/6",
                     "status": {"name": "DONE"},
                 },
             },
             {
                 "fields": {
                     "labels": ["label", "pagure.io:test2"],
-                    "description": "https://pagure.io/test2/issue/1",
+                    "external_url": "https://pagure.io/test2/issue/1",
                     "status": {"name": "IN_PROGRESS"},
                 },
             },
             {
                 "fields": {
                     "labels": ["label", "pagure.io:namespace/test1"],
-                    "description": None,
+                    "external_url": None,
                     "status": {"name": "CONFUSED"},
                 },
             },
@@ -137,7 +138,7 @@ TEST_PAGURE_JIRA_ISSUES = [
             {
                 "fields": {
                     "labels": ["label", "pagure.io:namespace/test1"],
-                    "description": "https://pagure.io/namespace/test1/issue/7",
+                    "external_url": "https://pagure.io/namespace/test1/issue/7",
                     "status": {"name": "MISSED_THE_BUS"},
                 },
             },
@@ -210,14 +211,14 @@ TEST_GITHUB_JIRA_ISSUES = [
             {
                 "fields": {
                     "labels": ["foo", "label", "github.com:org/test1"],
-                    "description": "https://github.com/org/test1/issues/4",
+                    "external_url": "https://github.com/org/test1/issues/4",
                     "status": {"name": "NEW"},
                 },
             },
             {
                 "fields": {
                     "labels": ["bar", "label", "github.com:test2"],
-                    "description": "https://github.com/test2/issues/2",
+                    "external_url": "https://github.com/test2/issues/2",
                     "status": {"name": "IN_PROGRESS"},
                 },
             },
@@ -225,21 +226,21 @@ TEST_GITHUB_JIRA_ISSUES = [
             {
                 "fields": {
                     "labels": ["label", "github.com:test2"],
-                    "description": "https://github.com/test2/issues/6",
+                    "external_url": "https://github.com/test2/issues/6",
                     "status": {"name": "DONE"},
                 },
             },
             {
                 "fields": {
                     "labels": ["label", "github.com:test2"],
-                    "description": "https://github.com/test2/issues/1",
+                    "external_url": "https://github.com/test2/issues/1",
                     "status": {"name": "IN_PROGRESS"},
                 },
             },
             {
                 "fields": {
                     "labels": ["label", "github.com:org/test1"],
-                    "description": None,
+                    "external_url": None,
                     "status": {"name": "CONFUSED"},
                 },
             },
@@ -247,7 +248,7 @@ TEST_GITHUB_JIRA_ISSUES = [
             {
                 "fields": {
                     "labels": ["label", "github.com:org/test1"],
-                    "description": "https://github.com/org/test1/issues/7",
+                    "external_url": "https://github.com/org/test1/issues/7",
                     "status": {"name": "MISSED_THE_BUS"},
                 },
             },
@@ -272,8 +273,6 @@ def mock_jira__get_issues_by_labels(labels: str | Collection[str], closed=False)
 
 def mock_jira__create_issue(
     context: dict,
-    summary: str,
-    description: str,
     url: str,
     labels: Collection[str] | str,
 ):
@@ -285,10 +284,10 @@ def mock_jira__create_issue(
     return JiraIssue.model_validate(
         {
             "key": f"CPE-{id_}",
-            "summary": summary,
+            "external_url": url,
             "labels": labels,
             "fields": {
-                "description": f"{url}\n\n{description}",
+                "external_url": f"{url}",
                 "status": {"name": "NEW"},
             },
         }
@@ -431,6 +430,7 @@ def gen_test_config(*, instances_enabled, repositories_enabled):
                 "default_issue_type": "Story",
                 "label": "label",
                 "story_points_field": "story_points",
+                "external_url_field": "external_url",
                 "statuses": {
                     "new": "NEW",
                     "assigned": "IN_PROGRESS",

--- a/tests/config/test_main.py
+++ b/tests/config/test_main.py
@@ -17,6 +17,7 @@ EXPECTED_CONFIG = {
             "label": "label",
             "project": "Project",
             "story_points_field": "",
+            "external_url_field": "",
             "statuses": {
                 "assigned": "IN_PROGRESS",
                 "blocked": "BLOCKED",

--- a/tests/config/test_main.py
+++ b/tests/config/test_main.py
@@ -18,6 +18,11 @@ EXPECTED_CONFIG = {
             "project": "Project",
             "story_points_field": "",
             "external_url_field": "",
+            "blocked_field": "",
+            "blocked_values": {
+                "true": 1,
+                "false": 2,
+            },
             "statuses": {
                 "assigned": "IN_PROGRESS",
                 "blocked": "BLOCKED",

--- a/tests/test_jira_wrapper.py
+++ b/tests/test_jira_wrapper.py
@@ -30,6 +30,7 @@ TEST_JIRA_CONFIG = {
     "default_issue_type": "Story",
     "label": "label",
     "story_points_field": "story_points",
+    "external_url_field": "external_url",
     "statuses": {
         "new": "NEW",
         "assigned": "IN_PROGRESS",
@@ -147,8 +148,6 @@ class TestJIRA:
 
         with caplog.at_level("DEBUG"):
             retval = jira_obj.create_issue(
-                summary="summary",
-                description="description",
                 url="url",
                 labels=labels,
             )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -174,16 +174,12 @@ def test_sync_tickets(
     new_jira_ids = [len(TEST_JIRA_ISSUES) + 1, len(TEST_JIRA_ISSUES) + 2]
     pagure_issue = TEST_PAGURE_ISSUES[2]
     jira.create_issue.assert_any_call(
-        summary=pagure_issue["title"],
-        description=pagure_issue["content"],
         url=pagure_issue["full_url"],
         labels=[jira_config["label"], f"pagure.io:{pagure_issue['repo']}"],
     )
     assert "Creating JIRA ticket from https://pagure.io/namespace/test1/issue/3" in caplog.text
     github_issue = TEST_GITHUB_ISSUES[2]
     jira.create_issue.assert_any_call(
-        summary=github_issue["title"],
-        description=github_issue["body"],
         url=github_issue["html_url"],
         labels=[jira_config["label"], f"github.com:{github_issue['repo']}"],
     )


### PR DESCRIPTION
Our JIRA project now supports sync_from_upstream, this will let us simplify the jira_sync. Instead of parsing description for URL let's use URL field and set only summary field, the rest will be done by automation on the project.