### PR TITLE
Filter retrieved closed issues

### DIFF
--- a/jira_sync/jira_wrapper.py
+++ b/jira_sync/jira_wrapper.py
@@ -71,12 +71,13 @@ class JIRA:
         return self._jira
 
     def get_issues_by_labels(
-        self, labels: str | Collection[str], closed: bool = False
+        self, labels: str | Collection[str], issues_url: Collection[str] = [], closed: bool = False
     ) -> list[Issue]:
         """
         Retrieve issues for the specified labels.
 
         :param labels: Labels to retrieve the issues by
+        :param issues_url: URLs to match in external url field
         :param closed: Whether to return closed issues
 
         :return: List of issues
@@ -87,6 +88,12 @@ class JIRA:
         if self.run_mode == JiraRunMode.DRY_RUN:
             log.info("Skipping getting JIRA issues by labels: %s", ", ".join(labels))
             return []
+
+        urls_filter = ""
+
+        if issues_url:
+            urls = ", ".join(f'"{url}"' for url in issues_url)
+            urls_filter = f' AND "External Issue URL" IN ({urls})'
 
         labels_str = ", ".join(f'"{label}"' for label in labels)
 
@@ -99,7 +106,8 @@ class JIRA:
             jira.client.ResultList[Issue],
             self.jira.search_issues(
                 f'project = "{self.jira_config.project}" AND labels IN ({labels_str})'
-                + f" AND {status_blurb}",
+                + f" AND {status_blurb}"
+                + urls_filter,
                 maxResults=0,
             ),
         )

--- a/jira_sync/sync_mgr.py
+++ b/jira_sync/sync_mgr.py
@@ -216,8 +216,11 @@ class SyncManager:
 
         log.info("Creating/reopening JIRA issues for unmatched forge issues…")
 
+        forge_issues_urls = [issue.full_url for issue in forge_issues]
         log.info("Retrieving list of closed JIRA issues…")
-        closed_jira_issues = self._jira.get_issues_by_labels(self._jira_config.label, closed=True)
+        closed_jira_issues = self._jira.get_issues_by_labels(
+            self._jira_config.label, forge_issues_urls, closed=True
+        )
         log.info("Retrieved %d closed JIRA issues", len(closed_jira_issues))
 
         log.info("Matching closed JIRA issues with unmatched forge issues…")

--- a/tests/common.py
+++ b/tests/common.py
@@ -260,15 +260,21 @@ TEST_GITHUB_JIRA_ISSUES = [
 TEST_JIRA_ISSUES = TEST_PAGURE_JIRA_ISSUES + TEST_GITHUB_JIRA_ISSUES
 
 
-def mock_jira__get_issues_by_labels(labels: str | Collection[str], closed=False):
+def mock_jira__get_issues_by_labels(
+    labels: str | Collection[str], issues_url: Collection[str] = [], closed=False
+):
     if isinstance(labels, str):
         labels = [labels]
-    return [
+    issues = [
         issue
         for issue in TEST_JIRA_ISSUES
         if any(label in issue.fields.labels for label in labels)
         and (issue.fields.status.name == "DONE") == closed
     ]
+    if issues_url:
+        issues = [issue for issue in issues if issue.fields.external_url in (issues_url)]
+
+    return issues
 
 
 def mock_jira__create_issue(

--- a/tests/test_jira_wrapper.py
+++ b/tests/test_jira_wrapper.py
@@ -101,7 +101,7 @@ class TestJIRA:
 
         if run_mode != JiraRunMode.DRY_RUN:
             issue = mock.Mock()
-            issue.fields.description = f"{ISSUE_URL}\nSome\nmore\ntext."
+            issue.fields.external_url = f"{ISSUE_URL}"
             jira_obj.jira.search_issues.return_value = [issue]
 
         if labels_as_string:
@@ -109,7 +109,12 @@ class TestJIRA:
         else:
             labels = ["labels"]
 
-        retval = jira_obj.get_issues_by_labels(labels=labels, closed=closed)
+        if closed:
+            retval = jira_obj.get_issues_by_labels(
+                labels=labels, issues_url=[ISSUE_URL], closed=closed
+            )
+        else:
+            retval = jira_obj.get_issues_by_labels(labels=labels, closed=closed)
 
         if run_mode == JiraRunMode.DRY_RUN:
             assert jira_obj._jira is None
@@ -127,6 +132,7 @@ class TestJIRA:
         assert 'labels IN ("labels")' in snippets
         if closed:
             assert 'status IN ("Done", "Closed")' in snippets
+            assert f'"External Issue URL" IN ("{ISSUE_URL}")' in snippets
         else:
             assert 'status NOT IN ("Done", "Closed")' in snippets
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -143,7 +143,7 @@ def test_sync_tickets(
 
     assert jira.get_issues_by_labels.call_args_list == [
         mock.call("label"),
-        mock.call("label", closed=True),
+        mock.call("label", mock.ANY, closed=True),
     ]
     assert all(f"Querying repository pagure.io:{name}" in caplog.text for name in TEST_PAGURE_REPOS)
     assert all(

--- a/tests/test_sync_mgr.py
+++ b/tests/test_sync_mgr.py
@@ -332,7 +332,7 @@ class TestSyncManager:
 
         assert "Creating/reopening JIRA issues for unmatched forge issues" in caplog.text
         sync_mgr._jira.get_issues_by_labels.assert_called_once_with(
-            sync_mgr._jira_config.label, closed=True
+            sync_mgr._jira_config.label, ["URL0", "URL1"], closed=True
         )
         mock_match_jira_forge_issues.assert_called_once_with(
             sync_mgr._jira.get_issues_by_labels.return_value, forge_issues


### PR DESCRIPTION
To be able to retrieve only the closed issues that we care about let's use the external issue URL field. This will only retrieve closed JIRA issues that are linked to unmatched forge issues.

Fixes #111