### PR TITLE
Fix gitlab group query

### DIFF
--- a/jira_sync/repositories/gitlab.py
+++ b/jira_sync/repositories/gitlab.py
@@ -167,18 +167,17 @@ class GitLabInstance(GitLabBase, Instance):
             match query_params:
                 case {"org": org}:
                     encoded_url = urllib.parse.quote_plus(org)
-                    endpoint = f"/groups/{encoded_url}/projects"
+                    endpoint = f"/groups/{encoded_url}/projects?include_subgroups=true"
                 case {"user": user}:  # pragma: no branch
                     endpoint = f"/users/{user}/repos"
 
             response = None
-
             while next_page := self.get_next_page(endpoint=endpoint, response=response):
                 response = requests.get(**next_page)
                 if response.status_code == requests.codes.ok:
                     api_result = response.json()
                     repos |= {
-                        repo["full_name"]: repo_params
+                        repo["path_with_namespace"]: repo_params
                         for repo in api_result
                         if repo["issues_enabled"] and not repo["archived"]
                     }

--- a/tests/repositories/test_gitlab.py
+++ b/tests/repositories/test_gitlab.py
@@ -122,7 +122,7 @@ class TestGitLabInstance(GitLabTestBase, BaseTestInstance):
                 json=mock.Mock(
                     return_value=[
                         {
-                            "full_name": f"/{key.upper()}/{repo}",
+                            "path_with_namespace": f"/{key.upper()}/{repo}",
                             "issues_enabled": issues_enabled,
                             "archived": archived,
                             "disabled": False,
@@ -138,7 +138,7 @@ class TestGitLabInstance(GitLabTestBase, BaseTestInstance):
         ]
 
         if key == "org":
-            endpoint = f"/groups/{key.upper()}/projects"
+            endpoint = f"/groups/{key.upper()}/projects?include_subgroups=true"
         else:
             endpoint = f"/{key}s/{key.upper()}/repos"
 


### PR DESCRIPTION
The gitlab has subgroups as well, which are not included by default. Adding include_subgroups param to API call will include them as well. There was also issue with using full_name param in returned JSON, which doesn't exists and instead we should use path_with_namespace.